### PR TITLE
Python 2.7 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 
 python:
+  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -12,11 +13,11 @@ sudo: false
 
 install:
   - python setup.py install
-  - pip install -U pytest coverage pytest-cov coveralls
+  - pip install -U pytest coverage pytest-cov codecov
 
 script:
   - python setup.py test
 
 after_success:
-  - coveralls
+  - codecov
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,8 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
   matrix:
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35"
@@ -16,7 +18,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "python -m pip install --disable-pip-version-check --user --upgrade pip"
   - "pip install -U setuptools pytest"
-  - "pip install coverage pytest-cov coveralls"
+  - "pip install coverage pytest-cov codecov"
 
 build_script:
   - "python setup.py install"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 import glob
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 
 class PyTest(TestCommand):

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'warcit',
         ],
     install_requires=[
-        'warcio',
+        'warcio>=1.6.0',
         'cchardet'
         ],
     zip_safe=True,

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'warcit',
         ],
     install_requires=[
-        'warcio>=1.6.0',
+        'warcio>=1.6.1',
         'cchardet'
         ],
     zip_safe=True,

--- a/warcit/warcit.py
+++ b/warcit/warcit.py
@@ -8,22 +8,18 @@ import logging
 import zipfile
 import fnmatch
 import csv
+import errno
 
 from warcio.warcwriter import WARCWriter
 from warcio.timeutils import datetime_to_iso_date, timestamp_to_iso_date
 from warcio.timeutils import pad_timestamp, PAD_14_DOWN, DATE_TIMESPLIT
+import warcio.utils
 from contextlib import closing
 from collections import OrderedDict
 import cchardet
 
 
 BUFF_SIZE = 2048
-
-# ============================================================================
-if sys.version_info < (3, 3):  #pragma: no cover
-    xb_supported = False
-else:  #pragma: no cover
-    xb_supported = True
 
 
 # ============================================================================
@@ -397,14 +393,9 @@ class WARCIT(object):
                 return 1
 
         try:
-            if self.mode == 'xb' and not xb_supported:  #pragma: no cover
-                fd = os.open(self.name, os.O_EXCL | os.O_CREAT | os.O_WRONLY)
-                output = os.fdopen(fd, 'w', 0x664)
-            else:
-                output = open(self.name, self.mode)
+            output = warcio.utils.open(self.name, self.mode)
         except OSError as e:
             # ensure only file exists handling
-            import errno
             if e.errno != errno.EEXIST:
                 raise
 

--- a/warcit/warcit.py
+++ b/warcit/warcit.py
@@ -51,7 +51,7 @@ def main(args=None):
 
     parser.add_argument('-a', '--append', action='store_true')
     parser.add_argument('-o', '--overwrite', action='store_true')
-   
+
 
     parser.add_argument('--use-magic', '--magic',
                         help='''Select method for MIME type guessing:
@@ -88,7 +88,7 @@ def main(args=None):
                         help='''Do not include technical information about the resulting
                                 WARC file's creation.''',
                         action='store_true')
-    
+
     parser.add_argument('--no-gzip',
                         help='''Do not compress WARC file.''',
                         action='store_true')
@@ -263,7 +263,7 @@ class WARCIT(object):
             return False
 
         self.filemap = []
-        
+
         with closing(mapfile_h):
             try:
                 if self.mapfile.lower().endswith('.tsv'):
@@ -273,7 +273,7 @@ class WARCIT(object):
             except Exception as e:
                 self.logger.error(e)
                 return False
-            
+
             # csv validation
             for column in csvreader.fieldnames:
                 if not column in ['file', 'URL', 'Content-Type', 'timestamp']:
@@ -304,7 +304,7 @@ class WARCIT(object):
                                                                          'Content-Type', 'mime', 
                                                                          'charset'])
         self.logfile_writer.writeheader()
-        
+
         return True
 
     def write_logfile(self, row):
@@ -321,7 +321,7 @@ class WARCIT(object):
                 if 'matched' in row:
                     self.logger.error('Mapfile row for "{}" matched a second time on file "{}". Please ensure file names in your mapfile are unique.'.format(row['file'], filename))
                     sys.exit(1)
-                
+
                 self.logger.debug('Matching row "{}" from mapfile.'.format(row['file']))
                 row['matched'] = True
                 return row
@@ -476,7 +476,7 @@ class WARCIT(object):
 
         warc_headers = {'WARC-Date': warc_date,
                         'WARC-Source-URI': source_uri,
-                        'WARC-Created-Date': writer._make_warc_date()
+                        'WARC-Creation-Date': writer._make_warc_date()
                        }
 
 
@@ -493,7 +493,7 @@ class WARCIT(object):
             self.logger.debug('Writing "{0}" ({1}) @ "{2}" from "{3}"'.format(url, warc_content_type, warc_date,
                                                                               file_info.full_filename))
 
-            
+
         self.write_logfile({
             'file': file_info.full_filename,
             'Record-Type': 'Resource',
@@ -521,7 +521,7 @@ class WARCIT(object):
 
         revisit_record = writer.create_revisit_record(index_url, digest, url, warc_date)
 
-        revisit_record.rec_headers.replace_header('WARC-Created-Date', revisit_record.rec_headers.get_header('WARC-Date'))
+        revisit_record.rec_headers.replace_header('WARC-Creation-Date', revisit_record.rec_headers.get_header('WARC-Date'))
         revisit_record.rec_headers.replace_header('WARC-Date', warc_date)
         revisit_record.rec_headers.replace_header('WARC-Source-URI', source_uri)
 
@@ -552,11 +552,11 @@ class WARCIT(object):
             mime = mimetypes.guess_type(file_info.url.split('?', 1)[0], False)
             if len(mime) == 2:
                 mime = mime[0]
-        
+
         elif self.use_magic == 'magic':
             with file_info.open() as fh:
                 mime = self.magic.from_buffer(fh.read(BUFF_SIZE))
-        
+
         elif self.use_magic == 'tika':
             # Tika might not return a Content-Type, a string, or a list.
             # In case of a list, the first (most likely) value is chosen. 
@@ -564,7 +564,7 @@ class WARCIT(object):
                 tika_content_type = self.tika_results['metadata']['Content-Type']
                 if isinstance(tika_content_type, list):
                     tika_content_type = tika_content_type[0]
-                
+
                 mime = tika_content_type.split(';', 1)[0]
             except:
                 mime = None


### PR DESCRIPTION
Add Python 2.7 support as well (using warcio 1.6.1) so warcit can work on older systems as well.
Also fixed typo with creation date header, should have been `WARC-Creation-Date` not `WARC-Created-Date`