### PR TITLE
Add trailing slash info to `url_prefix` help text

### DIFF
--- a/warcit/converter.py
+++ b/warcit/converter.py
@@ -42,7 +42,7 @@ def main(args=None):
 
     parser.add_argument('url_prefix',
                         help='''The base URL for all items to be included, including
-                                protocol. Example: https://cool.website:8080/files/''')
+                                protocol and trailing slash. Example: https://cool.website:8080/files/''')
 
     parser.add_argument('inputs', nargs='+',
                         help='''Paths of directories and/or files to be checked for conversion''')

--- a/warcit/warcit.py
+++ b/warcit/warcit.py
@@ -40,7 +40,7 @@ def main(args=None):
 
     parser.add_argument('url_prefix',
                         help='''The base URL for all items to be included, including
-                                protocol. Example: https://cool.website:8080/files/''')
+                                protocol and trailing slash. Example: https://cool.website:8080/files/''')
     parser.add_argument('inputs', nargs='+',
                         help='''Paths of directories and/or files to be included in
                                 the WARC file.''')


### PR DESCRIPTION
Closes #26 

Adds a note about the trailing slash being included in the URL prefix to the help text.  This caught me up the first time I used warcit [and it looks like I'm not the only one!](https://github.com/webrecorder/warcit/issues/26)

Hopefully this helps make things clearer for new users?