### PR TITLE
Adjusted WARC-Date for Revisit-Records

### DIFF
--- a/warcit/warcit.py
+++ b/warcit/warcit.py
@@ -552,7 +552,7 @@ class WARCIT(BaseTool):
         revisit_record = writer.create_revisit_record(index_url, digest, url, warc_date, None, warc_headers_dict\
                     = {"WARC-Date" : warc_date})
 
-        revisit_record.rec_headers['WARC-Creation-Date'] = warc_date
+        revisit_record.rec_headers['WARC-Creation-Date'] = creation_date
         revisit_record.rec_headers['WARC-Source-URI'] = source_uri
 
         self.count += 1

--- a/warcit/warcit.py
+++ b/warcit/warcit.py
@@ -545,12 +545,14 @@ class WARCIT(BaseTool):
         self.logger.debug('Adding auto-index: {0} -> {1}'.format(index_url, url))
 
         warc_date = record.rec_headers['WARC-Date']
+        creation_date = record.rec_headers['WARC-Creation-Date']
         source_uri = record.rec_headers['WARC-Source-URI']
+        
+        # warc_date of the index file is handed down so that revisit record has the same date as index file
+        revisit_record = writer.create_revisit_record(index_url, digest, url, warc_date, None, warc_headers_dict\
+                    = {"WARC-Date" : warc_date})
 
-        revisit_record = writer.create_revisit_record(index_url, digest, url, warc_date)
-
-        # no creation date needed, as it matches warc-date
-        #revisit_record.rec_headers['WARC-Creation-Date'] = warc_date
+        revisit_record.rec_headers['WARC-Creation-Date'] = warc_date
         revisit_record.rec_headers['WARC-Source-URI'] = source_uri
 
         self.count += 1


### PR DESCRIPTION
Fixes #31 

Changed method:
make_index_revisit

Information about the WARC-Date of the index record is passed on to the create_revisit_record-method, so that the revisit record gets the same WARC-Date entry as the index record.
Accordingly, the revisit record also gets a WARC-Creation-Date with the actual timestamp of the creation of the record.

As far as tested it works both with --fixed-dt and with the original time stamp of files that are "warced".